### PR TITLE
Add #ifndef _WIN32 to src/gettz.cpp to hide strtok_r

### DIFF
--- a/src/gettz.cpp
+++ b/src/gettz.cpp
@@ -107,6 +107,8 @@ char *findDefaultTZ(char *tz, size_t tzSize) {
     return ret;
 }
 
+#ifndef _WIN32
+
 // Look for tag=someValue within filename.  When found, return someValue
 // in the provided value parameter up to valueSize in length.  If someValue
 // is enclosed in quotes, remove them. 
@@ -156,3 +158,5 @@ char *getValue(const char *filename, const char *tag, char *value, size_t valueS
         return value;
     return NULL;
 }
+
+#endif


### PR DESCRIPTION
On my Windows machine `R CMD build` tried to build using /src/gettz.cpp which
errored on the undefinedness of `strtok_r`.

Fixes #1 
