### PR TITLE
Add #ifndef _WIN32 to src/gettz.cpp to hide strtok_r

### DIFF
--- a/src/gettz.cpp
+++ b/src/gettz.cpp
@@ -111,6 +111,9 @@ char *findDefaultTZ(char *tz, size_t tzSize) {
 // in the provided value parameter up to valueSize in length.  If someValue
 // is enclosed in quotes, remove them. 
 char *getValue(const char *filename, const char *tag, char *value, size_t valueSize) {
+
+#ifndef _WIN32
+
     char buffer[128], *lasts;
     int foundTag = 0;
 
@@ -154,5 +157,6 @@ char *getValue(const char *filename, const char *tag, char *value, size_t valueS
     }
     if (foundTag)
         return value;
+#endif
     return NULL;
 }


### PR DESCRIPTION
On my Windows machine `R CMD build` tried to build using /src/gettz.cpp which
errored on the undefinedness of `strtok_r`.

Fixes #1 by putting defines inside the function.
